### PR TITLE
FIX: Android text selection handles not visible

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.memeshart.save_gfy"
-        minSdkVersion 24
+        minSdkVersion 26
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/app/src/main/kotlin/com/memeshart/save_gfy/CustomNativeWebView.kt
+++ b/android/app/src/main/kotlin/com/memeshart/save_gfy/CustomNativeWebView.kt
@@ -1,0 +1,10 @@
+package com.memeshart.save_gfy
+
+import android.content.Context
+import android.webkit.WebView
+
+class CustomNativeWebView internal constructor(context: Context) : WebView(context) {
+    override fun hasWindowFocus(): Boolean {
+        return true
+    }
+}

--- a/android/app/src/main/kotlin/com/memeshart/save_gfy/WebViewFactory.kt
+++ b/android/app/src/main/kotlin/com/memeshart/save_gfy/WebViewFactory.kt
@@ -8,7 +8,7 @@ import io.flutter.plugin.platform.PlatformViewFactory
 
 class WebViewFactory(private val messenger: BinaryMessenger) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
     override fun create(context: Context, id: Int, o: Any?): PlatformView {
-        return MyWebView(context, messenger, id)
+        return FlutterWebView(context, messenger, id)
     }
 
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,7 +11,6 @@ import 'package:save_gfy/services/logger_service.dart';
 import 'package:save_gfy/values/app_config.dart';
 import 'package:save_gfy/values/routes.dart' as SaveGfyRoutes;
 
-
 const appTitle = 'Save GFY';
 
 const channelName = 'memeshart.com/save_gfy';

--- a/lib/services/gfycat_service.dart
+++ b/lib/services/gfycat_service.dart
@@ -13,8 +13,7 @@ class GfycatService implements SourceService {
 
   final WebViewController webViewController;
 
-  static const String _javascript =
-      'JSON.stringify(___INITIAL_STATE__.cache.gifs)';
+  static const String _javascript = '___INITIAL_STATE__.cache.gifs';
 
   static const Map<DownloadType, String> _extensions = {
     DownloadType.mp4: '.mp4',


### PR DESCRIPTION
- When selecting text in the WebView, the teardrop handles on the corners of the highlighted
  text are not showing.
- Followed the direction of the conversation from https://github.com/flutter/flutter/issues/24584.
- Modeled change to MyWebView after https://github.com/flutter/plugins/blob/master/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java.
- Renamed MyWebView to FlutterWebView.
- Use native implementation of WebView.evaluateJavaScript for KITKAT and greater and original implementation for other versions.

Provides better user experience which follows the default behavior better.