### PR TITLE
FIX: Add padding to loading SnackBar

### DIFF
--- a/lib/features/viewer/viewer.dart
+++ b/lib/features/viewer/viewer.dart
@@ -35,7 +35,10 @@ class _ViewerState extends State<Viewer> {
       final loadingSnackbarController = _showSnackBar(
         content: Row(children: [
           CircularProgressIndicator(),
-          Text('Loading...'),
+          Container(
+            padding: EdgeInsets.only(left: kTabLabelPadding.left),
+            child: Text('Loading...'),
+          ),
         ]),
         duration: timeoutDuration,
       );


### PR DESCRIPTION
- Querying downloads loading SnackBar had no visual space between the spinner and the text.

Helps provide better visualization and readability to the user.